### PR TITLE
Metrics

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,6 +6,7 @@
     "ping",
     "delta"
   ],
+  "service": "browsenpm",
   "redis": {
     "host": "localhost",
     "port": 6379

--- a/index.js
+++ b/index.js
@@ -3,19 +3,22 @@
 var path = require('path')
   , BigPipe = require('bigpipe')
   , connect = require('connect')
-  , config = require('./config')
-  , debug = require('debug')('browsenpm:server');
+  , memory = require('memory-producer')
+  , debug = require('debug')('browsenpm:server')
+  , config = require('./config');
 
 //
 // Setup all the configuration
 //
-var port = config.get('port');
+var port = config.get('port')
+  , service = config.get('service');
 
 //
 // Initialize plugins and add a valid path to base for plugin-layout.
 //
 var watch = require('bigpipe-watch')
   , layout = require('bigpipe-layout')
+  , godot = require('bigpipe-godot')
   , probe = require('./plugins/npm-probe');
 
 //
@@ -31,8 +34,13 @@ layout.options = {
 var pipe = new BigPipe(require('http').createServer(), {
   pages: path.join(__dirname, 'pages'),
   dist: path.join(__dirname, 'dist'),
-  plugins: [ probe, layout, watch ]
+  plugins: [ probe, layout, watch , godot]
 });
+
+//
+// Add some producers to the godot client if it exists
+//
+pipe.godot && pipe.godot.add(new Memory({ service: service }));
 
 //
 // Add middleware.

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "async": "~0.8.0",
     "bigpipe": "~0.5.0",
+    "bigpipe-godot": "^0.1.0",
     "bigpipe-layout": "~0.1.0",
     "bigpipe-watch": "~0.1.0",
     "connect": "~2.15.0",
@@ -38,8 +39,9 @@
     "debug": "~0.8.0",
     "dynamis": "~0.1.3",
     "ejs": "~1.0.0",
-    "handlebars": "~2.0.0-alpha.2",
     "githulk": "~0.0.6",
+    "handlebars": "~2.0.0-alpha.2",
+    "memory-producer": "^0.1.1",
     "nconf": "~0.6.9",
     "npm-dependencies-pagelet": "~0.1.0",
     "npm-documentation-pagelet": "~0.2.0",


### PR DESCRIPTION
Add [`bigpipe-godot`](https://github.com/bigpipe/bigpipe-godot) plugin to easily hook in an optional [`godot`](https://github.com/nodejitsu/godot) client if we have the correct config.
